### PR TITLE
PreviousMixingの出力重み周り整理

### DIFF
--- a/src/models/components/channel_mixing.py
+++ b/src/models/components/channel_mixing.py
@@ -12,13 +12,15 @@ class ChannelMixing(nn.Module):
         self.previous_mixing_k = PreviousMixing(dim)
         self.previous_mixing_r = PreviousMixing(dim)
         self.Wv = nn.Linear(dim, dim, bias=False)
+        self.Wk = nn.Linear(dim, dim, bias=False)
+        self.Wr = nn.Linear(dim, dim, bias=False)
         self.sigmoid = nn.Sigmoid()
         self.relu = nn.ReLU()
 
     # (len, *, dim) -> (len, *, dim)
     def forward(self, x: Tensor) -> Tensor:
-        vk = self.Wv(torch.pow(self.relu(self.previous_mixing_k(x)), 2))
-        return self.sigmoid(self.previous_mixing_r(x)) * vk
+        vk = self.Wv(torch.pow(self.relu(self.Wk(self.previous_mixing_k(x))), 2))
+        return self.sigmoid(self.Wr(self.previous_mixing_r(x))) * vk
 
     def clear_hidden(self):
         self.previous_mixing_k.clear_hidden()

--- a/src/models/components/ema_mixing.py
+++ b/src/models/components/ema_mixing.py
@@ -7,7 +7,6 @@ class EMAMixing(nn.Module):
     def __init__(self, dim: int):
         super().__init__()
         self.dim = dim
-        self.W = nn.Linear(dim, dim, bias=False)
         self.factor = nn.Parameter(torch.rand(dim))
         self.sigmoid = nn.Sigmoid()
         self.x_mix_last = None
@@ -33,7 +32,7 @@ class EMAMixing(nn.Module):
             + (1 - factor) * x_conv_factor_progression
         )
         self.x_mix_last = x_mix[-1]
-        return self.W(x_mix)
+        return x_mix
 
     def clear_hidden(self):
         self.x_mix_last = None


### PR DESCRIPTION
## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
PreviousMixing（とEMAMixing）には出力線形層を持たせない

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
* EMAMixingから線形層削除
* ChannelMixingにPreviousMixing後の線形層追加

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
