### PR TITLE
隠れ状態のテストを修正

### DIFF
--- a/tests/models/components/test_ema_mixing.py
+++ b/tests/models/components/test_ema_mixing.py
@@ -19,9 +19,13 @@ from src.models.components.ema_mixing import EMAMixing
 def test_ema_mixing(len, batch, dim):
     ema_mixing = EMAMixing(dim)
     x = torch.rand(len, batch, dim)
+    assert ema_mixing.x_mix_last is None
     x = ema_mixing(x)
+    assert ema_mixing.x_mix_last is not None
     x = ema_mixing(x)
     ema_mixing.clear_hidden()
+    assert ema_mixing.x_mix_last is None
     x = ema_mixing(x)
+    assert ema_mixing.x_mix_last is not None
     x = ema_mixing(x)
     assert x.size() == torch.Size([len, batch, dim])

--- a/tests/models/components/test_previous_mixing.py
+++ b/tests/models/components/test_previous_mixing.py
@@ -20,9 +20,13 @@ def test_previous_mixing(len, dim):
     other_axes = torch.randint(1, 4, (torch.randint(1, 3, (1,)).item(),))
     shape = (len, *other_axes, dim)
     x = torch.rand(shape)
+    assert previous_mixing.x_last is None
     x = previous_mixing(x)
+    assert previous_mixing.x_last is not None
     x = previous_mixing(x)
     previous_mixing.clear_hidden()
+    assert previous_mixing.x_last is None
     x = previous_mixing(x)
+    assert previous_mixing.x_last is not None
     x = previous_mixing(x)
     assert x.size() == shape

--- a/tests/models/components/test_time_mixing.py
+++ b/tests/models/components/test_time_mixing.py
@@ -19,11 +19,17 @@ from src.models.components.time_mixing import TimeMixing
 def test_time_mixing(len, batch, dim):
     time_mixing = TimeMixing(dim)
     x = torch.rand(len, batch, dim)
+    assert time_mixing.numerator_last is None
+    assert time_mixing.denominator_last is None
     x = time_mixing(x)
+    assert time_mixing.numerator_last is not None
+    assert time_mixing.denominator_last is not None
     x = time_mixing(x)
     time_mixing.clear_hidden()
     assert time_mixing.numerator_last is None
     assert time_mixing.denominator_last is None
     x = time_mixing(x)
+    assert time_mixing.numerator_last is not None
+    assert time_mixing.denominator_last is not None
     x = time_mixing(x)
     assert x.size() == torch.Size([len, batch, dim])


### PR DESCRIPTION
## 概要

* 初期状態で隠れ状態がNone
* 処理を行うと隠れ状態が更新される
* clear_hidden()でリセットされる
* 隠れ状態がNoneであるかに関係なく処理が実行できる
ことを検証できるようにする

## 変更内容

初期状態とclear_hidden後はNoneであること、1回処理したあとは隠れ状態がNoneでないことを検証するようにした

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?
