### PR TITLE
2023/05/08のRWKVの学習

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     make \
     nodejs \
     npm \
+    screen \
     tzdata \
     wget \
     && rm -rf /var/lib/apt/lists/*

--- a/configs/callbacks/learning_rate_monitor.yaml
+++ b/configs/callbacks/learning_rate_monitor.yaml
@@ -1,0 +1,6 @@
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.LearningRateMonitor.html
+
+learning_rate_monitor:
+  _target_: lightning.pytorch.callbacks.LearningRateMonitor
+  logging_interval: null # "step" or "epoch"
+  log_momentum: False

--- a/configs/callbacks/rwkv.yaml
+++ b/configs/callbacks/rwkv.yaml
@@ -2,6 +2,7 @@ defaults:
   - model_checkpoint.yaml
   - model_summary.yaml
   - rich_progress_bar.yaml
+  - learning_rate_monitor.yaml
   - _self_
 
 model_checkpoint:

--- a/configs/callbacks/rwkv.yaml
+++ b/configs/callbacks/rwkv.yaml
@@ -8,6 +8,8 @@ model_checkpoint:
   dirpath: ${paths.output_dir}/checkpoints
   filename: "step_{step:08d}"
   save_last: True
+  monitor: "train/loss_avg"
+  mode: "min"
   auto_insert_metric_name: False
   every_n_train_steps: 100 # save checkpoint every 100 steps
 

--- a/configs/data/wiki.yaml
+++ b/configs/data/wiki.yaml
@@ -9,3 +9,4 @@ dataset:
     _target_: sentencepiece.SentencePieceProcessor
     model_file: ${paths.data_dir}/WikiCorpusJa/sp_tokenizer_32k.model
   ctx_len: 1024
+num_workers: 0 # always 0 or 1.

--- a/configs/experiment/rwkv_wiki.yaml
+++ b/configs/experiment/rwkv_wiki.yaml
@@ -16,6 +16,7 @@ seed: 12345
 trainer:
   max_steps: 100000
   precision: 32
+  max_epochs: null
 
 # logger:
 #   mlflow:

--- a/configs/experiment/rwkv_wiki.yaml
+++ b/configs/experiment/rwkv_wiki.yaml
@@ -15,7 +15,7 @@ seed: 12345
 
 trainer:
   max_steps: 100000
-  precision: 32
+  precision: "bf16-mixed"
   max_epochs: null
 
 # logger:
@@ -23,3 +23,5 @@ trainer:
 #     tags: ${tags}
 
 test: False
+
+float32_matmul_precision: "medium"

--- a/configs/experiment/rwkv_wiki.yaml
+++ b/configs/experiment/rwkv_wiki.yaml
@@ -11,10 +11,23 @@ task_name: "rwkv_wiki"
 
 tags: ["rwkv", "wiki"]
 
-seed: 12345
+seed: null # 42 is used in determisitic mode of the original implementation.
+
+data:
+  dataset:
+    ctx_len: 1024 # ~10M tokens at Japanese Wikipedia
+
+model:
+  scheduler:
+    lr_lambda:
+      init_lr: 1e-7 # ignored if warmup_steps is 0.
+      max_lr: 8e-4
+      final_lr: 1e-5
+      warmup_steps: 0
+      max_steps: 100000
 
 trainer:
-  max_steps: 100000
+  max_steps: 1000000
   precision: "bf16-mixed"
   max_epochs: null
 

--- a/configs/experiment/rwkv_wiki.yaml
+++ b/configs/experiment/rwkv_wiki.yaml
@@ -15,13 +15,13 @@ seed: null # 42 is used in determisitic mode of the original implementation.
 
 data:
   dataset:
-    ctx_len: 1024 # ~10M tokens at Japanese Wikipedia
+    ctx_len: 1024 # ~5G tokens in Japanese Wikipedia.
 
 model:
   scheduler:
     lr_lambda:
       init_lr: 1e-7 # ignored if warmup_steps is 0.
-      max_lr: 1e-4
+      max_lr: 8e-4
       final_lr: 1e-5
       warmup_steps: 0
       max_steps: 100000

--- a/configs/experiment/rwkv_wiki.yaml
+++ b/configs/experiment/rwkv_wiki.yaml
@@ -21,7 +21,7 @@ model:
   scheduler:
     lr_lambda:
       init_lr: 1e-7 # ignored if warmup_steps is 0.
-      max_lr: 8e-4
+      max_lr: 1e-4
       final_lr: 1e-5
       warmup_steps: 0
       max_steps: 100000
@@ -30,6 +30,7 @@ trainer:
   max_steps: 1000000
   precision: "bf16-mixed"
   max_epochs: null
+  gradient_clip_val: 1.0
 
 # logger:
 #   mlflow:

--- a/configs/model/rwkv_wiki.yaml
+++ b/configs/model/rwkv_wiki.yaml
@@ -7,6 +7,19 @@ optimizer:
   betas: [0.9, 0.99]
   eps: 1e-8
 
+scheduler:
+  _target_: torch.optim.lr_scheduler.LambdaLR
+  _partial_: true
+  lr_lambda:
+    _target_: src.models.components.warmup_exp_decay_lr_lambda.WarmupExpDecayLRLambda
+    base_lr: ${...optimizer.lr}
+    init_lr: 1e-7
+    max_lr: 8e-4 # If warmup_steps is 0, this value is used as initial learning rate.
+    final_lr: 1e-5
+    warmup_steps: 0 # If learning from pre-trained model, set other than 0.
+    max_steps: 10000
+scheduler_update_frequecy: 1 # steps
+
 net:
   _target_: src.models.components.rwkv_lang.RWKVLang
   dim: 512

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -50,3 +50,7 @@ ckpt_path: null
 
 # seed for random number generators in pytorch, numpy and python.random
 seed: null
+
+# matmul precision. If the GPU has Tensor Cores, this can be set to `high` or `medium`, otherwise it must be `highest`.
+# See https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision
+float32_matmul_precision: null

--- a/scripts/afk_train_rwkv.sh
+++ b/scripts/afk_train_rwkv.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+screen python src/train.py \
+    experiment=rwkv_wiki \
+    trainer=gpu \
+    data.num_workers=1 \
+    model.monitoring_interval=1000 \
+    callbacks.model_checkpoint.every_n_train_steps=1000 \
+    data.batch_size=16 \
+    trainer.max_steps=1_000_000 \

--- a/src/data/wiki_datamodule.py
+++ b/src/data/wiki_datamodule.py
@@ -8,7 +8,7 @@ from .components.wiki_dataset import SPTokenizingWikiDataset
 
 class WikiDataModule(LightningDataModule):
     """DataModule for Wikipedia dataset.
-    Note: This class can not be parallelized. So DataLoader `num_workers` is always 0.
+    Note: This class can not be parallelized. So DataLoader `num_workers` is always 0 or 1.
 
     Return Info:
         - shape: (batch_size, ctx_len)
@@ -20,6 +20,7 @@ class WikiDataModule(LightningDataModule):
         dataset: SPTokenizingWikiDataset,
         batch_size: int = 64,
         pin_memory: bool = False,
+        num_workers: int = 0,
     ):
         """Initialize WikiDataModule.
 
@@ -42,7 +43,7 @@ class WikiDataModule(LightningDataModule):
         return DataLoader(
             dataset=self.data_train,
             batch_size=self.hparams.batch_size,
-            num_workers=0,
+            num_workers=self.hparams.num_workers,
             pin_memory=self.hparams.pin_memory,
             shuffle=False,  # Can not shuffle because iterable dataset.
         )

--- a/src/models/components/warmup_exp_decay_lr_lambda.py
+++ b/src/models/components/warmup_exp_decay_lr_lambda.py
@@ -16,7 +16,7 @@ class WarmupExpDecayLRLambda:
         max_lr: float,
         final_lr: float,
         warmup_steps: int,
-        gamma: float,
+        max_steps: float,
     ) -> None:
         """Initialize WarmupExpDecayLRLambda class.
 
@@ -26,14 +26,15 @@ class WarmupExpDecayLRLambda:
             max_lr (float): Maximum learning rate. Returned at the last step of warmup.
             final_lr (float): Final learning rate. Returned after decay ends.
             warmup_steps (int): Warmup steps.
-            gamma (float): Decay rate.
+            max_steps (float): Maximum steps in training.
         """
         self.base_lr = base_lr
         self.init_lr = init_lr
         self.max_lr = max_lr
         self.final_lr = final_lr
         self.warmup_steps = warmup_steps
-        self.gamma = gamma
+        self.max_steps = max_steps
+        self.gamma = (final_lr / max_lr) ** (1 / (max_steps - warmup_steps))
 
     def __call__(self, epoch: int) -> Any:
         """Call WarmupExpDecayLRLambda class.

--- a/src/models/components/warmup_exp_decay_lr_lambda.py
+++ b/src/models/components/warmup_exp_decay_lr_lambda.py
@@ -1,0 +1,53 @@
+"""This file contains a class for warmup and exponential decay learning rate lambda."""
+
+from typing import Any
+
+
+class WarmupExpDecayLRLambda:
+    """This class warmup learning rate linearly and decay exponentially.
+
+    Note: This class will be used as a lambda function for torch.optim.lr_scheduler.LambdaLR.
+    """
+
+    def __init__(
+        self,
+        base_lr: float,
+        init_lr: float,
+        max_lr: float,
+        final_lr: float,
+        warmup_steps: int,
+        gamma: float,
+    ) -> None:
+        """Initialize WarmupExpDecayLRLambda class.
+
+        Args:
+            base_lr (float): Base learning rate. This is same to optimizer's initial learning rate.
+            init_lr (float): Initial learning rate. Returned at the first step.
+            max_lr (float): Maximum learning rate. Returned at the last step of warmup.
+            final_lr (float): Final learning rate. Returned after decay ends.
+            warmup_steps (int): Warmup steps.
+            gamma (float): Decay rate.
+        """
+        self.base_lr = base_lr
+        self.init_lr = init_lr
+        self.max_lr = max_lr
+        self.final_lr = final_lr
+        self.warmup_steps = warmup_steps
+        self.gamma = gamma
+
+    def __call__(self, epoch: int) -> Any:
+        """Call WarmupExpDecayLRLambda class.
+
+        Args:
+            epoch (int): Current epoch or step.
+
+        Returns:
+            float: Learning rate coefficient.
+        """
+
+        if epoch < self.warmup_steps:
+            lr = self.init_lr + (self.max_lr - self.init_lr) * (epoch / self.warmup_steps)
+        else:
+            lr = max(self.final_lr, self.max_lr * self.gamma ** (epoch - self.warmup_steps))
+
+        return lr / self.base_lr

--- a/src/models/rwkv_wiki_module.py
+++ b/src/models/rwkv_wiki_module.py
@@ -146,7 +146,9 @@ class RWKVWikiLitModule(LightningModule):
 
         mlf: MlflowClient = self.logger.experiment
         mlf.log_text(
-            self.logger.run_id, "\n".join(log_texts), f"generated_texts_step{self.global_step}.txt"
+            self.logger.run_id,
+            "\n".join(log_texts),
+            f"generated_texts_step{self.global_step:012d}.txt",
         )
 
     def configure_optimizers(self):

--- a/src/train.py
+++ b/src/train.py
@@ -50,6 +50,9 @@ def train(cfg: DictConfig) -> Tuple[dict, dict]:
     if cfg.get("seed"):
         L.seed_everything(cfg.seed, workers=True)
 
+    if cfg.get("float32_matmul_precision"):
+        torch.set_float32_matmul_precision(cfg.float32_matmul_precision)
+
     log.info(f"Instantiating datamodule <{cfg.data._target_}>")
     datamodule: LightningDataModule = hydra.utils.instantiate(cfg.data)
 

--- a/tests/models/components/test_warmup_exp_decay_lr_lambda.py
+++ b/tests/models/components/test_warmup_exp_decay_lr_lambda.py
@@ -11,17 +11,17 @@ def warmup_exp_decay_lr_lambda():
         max_lr=0.2,
         final_lr=0.001,
         warmup_steps=10,
-        gamma=0.95,
+        max_steps=100,
     )
 
 
-def test__init_(warmup_exp_decay_lr_lambda: WarmupExpDecayLRLambda):
+def test__init__(warmup_exp_decay_lr_lambda: WarmupExpDecayLRLambda):
     assert warmup_exp_decay_lr_lambda.base_lr == 0.1
     assert warmup_exp_decay_lr_lambda.init_lr == 0.01
     assert warmup_exp_decay_lr_lambda.max_lr == 0.2
     assert warmup_exp_decay_lr_lambda.final_lr == 0.001
     assert warmup_exp_decay_lr_lambda.warmup_steps == 10
-    assert warmup_exp_decay_lr_lambda.gamma == 0.95
+    assert warmup_exp_decay_lr_lambda.gamma == pytest.approx(0.005 ** (1 / 90), rel=1e-6)
 
 
 def test_warmup(warmup_exp_decay_lr_lambda: WarmupExpDecayLRLambda):
@@ -34,10 +34,10 @@ def test_warmup(warmup_exp_decay_lr_lambda: WarmupExpDecayLRLambda):
 
 def test_decay(warmup_exp_decay_lr_lambda: WarmupExpDecayLRLambda):
     assert warmup_exp_decay_lr_lambda(11) == pytest.approx(
-        (0.2 * 0.95 ** (11 - 10)) / 0.1, rel=1e-6
+        (0.2 * warmup_exp_decay_lr_lambda.gamma) / 0.1, rel=1e-6
     )
     assert warmup_exp_decay_lr_lambda(20) == pytest.approx(
-        (0.2 * 0.95 ** (20 - 10)) / 0.1, rel=1e-6
+        (0.2 * warmup_exp_decay_lr_lambda.gamma**10) / 0.1, rel=1e-6
     )
 
 

--- a/tests/models/components/test_warmup_exp_decay_lr_lambda.py
+++ b/tests/models/components/test_warmup_exp_decay_lr_lambda.py
@@ -1,0 +1,46 @@
+import pytest
+
+from src.models.components.warmup_exp_decay_lr_lambda import WarmupExpDecayLRLambda
+
+
+@pytest.fixture
+def warmup_exp_decay_lr_lambda():
+    return WarmupExpDecayLRLambda(
+        base_lr=0.1,
+        init_lr=0.01,
+        max_lr=0.2,
+        final_lr=0.001,
+        warmup_steps=10,
+        gamma=0.95,
+    )
+
+
+def test__init_(warmup_exp_decay_lr_lambda: WarmupExpDecayLRLambda):
+    assert warmup_exp_decay_lr_lambda.base_lr == 0.1
+    assert warmup_exp_decay_lr_lambda.init_lr == 0.01
+    assert warmup_exp_decay_lr_lambda.max_lr == 0.2
+    assert warmup_exp_decay_lr_lambda.final_lr == 0.001
+    assert warmup_exp_decay_lr_lambda.warmup_steps == 10
+    assert warmup_exp_decay_lr_lambda.gamma == 0.95
+
+
+def test_warmup(warmup_exp_decay_lr_lambda: WarmupExpDecayLRLambda):
+    assert warmup_exp_decay_lr_lambda(0) == 0.01 / 0.1
+    assert warmup_exp_decay_lr_lambda(5) == pytest.approx(
+        (0.01 + 0.5 * (0.2 - 0.01)) / 0.1, rel=1e-6
+    )
+    assert warmup_exp_decay_lr_lambda(10) == pytest.approx(0.2 / 0.1, rel=1e-6)
+
+
+def test_decay(warmup_exp_decay_lr_lambda: WarmupExpDecayLRLambda):
+    assert warmup_exp_decay_lr_lambda(11) == pytest.approx(
+        (0.2 * 0.95 ** (11 - 10)) / 0.1, rel=1e-6
+    )
+    assert warmup_exp_decay_lr_lambda(20) == pytest.approx(
+        (0.2 * 0.95 ** (20 - 10)) / 0.1, rel=1e-6
+    )
+
+
+def test_final_lr(warmup_exp_decay_lr_lambda: WarmupExpDecayLRLambda):
+    warmup_exp_decay_lr_lambda.final_lr = 0.001
+    assert warmup_exp_decay_lr_lambda(5000) == 0.001 / 0.1

--- a/tests/models/components/test_warmup_exp_decay_lr_lambda.py
+++ b/tests/models/components/test_warmup_exp_decay_lr_lambda.py
@@ -21,6 +21,7 @@ def test__init__(warmup_exp_decay_lr_lambda: WarmupExpDecayLRLambda):
     assert warmup_exp_decay_lr_lambda.max_lr == 0.2
     assert warmup_exp_decay_lr_lambda.final_lr == 0.001
     assert warmup_exp_decay_lr_lambda.warmup_steps == 10
+    assert warmup_exp_decay_lr_lambda.max_steps == 100
     assert warmup_exp_decay_lr_lambda.gamma == pytest.approx(0.005 ** (1 / 90), rel=1e-6)
 
 


### PR DESCRIPTION
## 概要

学習率の指数減衰を行うLambdaLRSchedulerの関数を追加。Warmup機能も一応つけました。
その他、パフォーマンスのチューニングを行っています。
`screen`の依存関係を追加しました。`screen`コマンドで仮想シェルに入るとSSHを切っても処理を続けてくれます。
差分がたくさんあってすみません。

- 学習率の曲線
![image](https://github.com/Geson-anko/RWKV-ReImpl/assets/59220704/b528d82d-8859-49ba-88e8-fa478e5d16c3)

- 損失の推移
![newplot (3)](https://github.com/Geson-anko/RWKV-ReImpl/assets/59220704/203f550c-f571-4b7c-adef-8273bb58238a)

## 注意
学習の途中でlossがnanになります。パラメータの値が爆発してしまったかもしれないです。学習率を下げると単にNaNが出るタイミングが遅くなるだけでした。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
