### PR TITLE
ChannelMixレイヤーの中間特徴量次元数を修正

### DIFF
--- a/configs/model/rwkv_wiki.yaml
+++ b/configs/model/rwkv_wiki.yaml
@@ -28,6 +28,7 @@ net:
     _target_: src.models.components.rwkv_lang.RWKV
     dim: ${..dim}
     depth: 6
+    hidden_dim_factor: 4
 
 monitoring_text_dataset:
   _target_: src.data.components.text_dataset.SPTokenizingTextDataset

--- a/src/models/components/channel_mixing.py
+++ b/src/models/components/channel_mixing.py
@@ -6,13 +6,15 @@ from .previous_mixing import PreviousMixing
 
 
 class ChannelMixing(nn.Module):
-    def __init__(self, dim: int):
+    def __init__(self, dim: int, hidden_dim_factor: int = 4):
         super().__init__()
         self.dim = dim
+        self.hidden_dim_factor = hidden_dim_factor
+        hidden_dim = dim * hidden_dim_factor
         self.previous_mixing_k = PreviousMixing(dim)
         self.previous_mixing_r = PreviousMixing(dim)
-        self.Wv = nn.Linear(dim, dim, bias=False)
-        self.Wk = nn.Linear(dim, dim, bias=False)
+        self.Wk = nn.Linear(dim, hidden_dim, bias=False)
+        self.Wv = nn.Linear(hidden_dim, dim, bias=False)
         self.Wr = nn.Linear(dim, dim, bias=False)
         self.sigmoid = nn.Sigmoid()
         self.relu = nn.ReLU()

--- a/src/models/components/rwkv.py
+++ b/src/models/components/rwkv.py
@@ -8,9 +8,9 @@ from .rwkv_block import RWKVBlock
 
 
 class RWKV(nn.Module):
-    def __init__(self, dim: int, depth: int):
+    def __init__(self, dim: int, depth: int, hidden_dim_factor: int = 4):
         super().__init__()
-        self.block_list = nn.ModuleList([RWKVBlock(dim) for _ in range(depth)])
+        self.block_list = nn.ModuleList([RWKVBlock(dim, hidden_dim_factor) for _ in range(depth)])
 
     def forward(self, x):
         for block in self.block_list:

--- a/src/models/components/rwkv_block.py
+++ b/src/models/components/rwkv_block.py
@@ -7,10 +7,10 @@ from .time_mixing import TimeMixing
 
 
 class RWKVBlock(nn.Module):
-    def __init__(self, dim: int):
+    def __init__(self, dim: int, hidden_dim_factor: int = 4):
         super().__init__()
         self.time_mixing = TimeMixing(dim)
-        self.channel_mixing = ChannelMixing(dim)
+        self.channel_mixing = ChannelMixing(dim, hidden_dim_factor)
         self.layer_norm = nn.LayerNorm(dim)
 
     # (len, batch, dim) -> (len, batch, dim)

--- a/tests/models/components/test_channel_mixing.py
+++ b/tests/models/components/test_channel_mixing.py
@@ -8,15 +8,20 @@ from src.models.components.channel_mixing import ChannelMixing
     """
     len,
     dim,
+    hidden_dim_factor,
     """,
     [
-        (1024, 512),
-        (1024, 1024),
-        (2048, 1024),
+        (1024, 16, 4),
+        (1024, 32, 2),
+        (2048, 16, 1),
     ],
 )
-def test_channel_mixing(len, dim):
-    channel_mixing = ChannelMixing(dim)
+def test_channel_mixing(len, dim, hidden_dim_factor):
+    channel_mixing = ChannelMixing(dim, hidden_dim_factor)
+
+    assert channel_mixing.dim == dim
+    assert channel_mixing.hidden_dim_factor == hidden_dim_factor
+
     other_axes = torch.randint(1, 4, (torch.randint(1, 3, (1,)).item(),))
     shape = (len, *other_axes, dim)
     x = torch.rand(shape)

--- a/tests/models/components/test_rwkv.py
+++ b/tests/models/components/test_rwkv.py
@@ -12,9 +12,9 @@ from src.models.components.rwkv import RWKV
     depth,
     """,
     [
-        (1024, 1, 512, 2),
-        (1024, 4, 1024, 1),
-        (512, 16, 256, 3),
+        (1024, 1, 32, 2),
+        (1024, 4, 64, 1),
+        (512, 16, 16, 3),
     ],
 )
 def test_rwkv(len, batch, dim, depth):

--- a/tests/models/components/test_rwkv_block.py
+++ b/tests/models/components/test_rwkv_block.py
@@ -11,9 +11,9 @@ from src.models.components.rwkv_block import RWKVBlock
     dim,
     """,
     [
-        (1024, 1, 512),
-        (1024, 4, 1024),
-        (512, 16, 256),
+        (1024, 1, 32),
+        (1024, 4, 64),
+        (512, 16, 16),
     ],
 )
 def test_rwkv_block(len, batch, dim):

--- a/tests/models/components/test_rwkv_lang.py
+++ b/tests/models/components/test_rwkv_lang.py
@@ -14,9 +14,9 @@ from src.models.components.rwkv_lang import RWKVLang
     vocab_size,
     """,
     [
-        (1024, 1, 512, 2, 123),
-        (1024, 4, 1024, 1, 432),
-        (512, 16, 256, 3, 915),
+        (1024, 1, 32, 2, 123),
+        (1024, 4, 64, 1, 432),
+        (512, 16, 16, 3, 915),
     ],
 )
 def test_rwkv_lang(len, batch, dim, depth, vocab_size):


### PR DESCRIPTION
## 概要

ChannelMixのkeyとvalueの中間特徴量を公式の実装に基づき4倍にしました。

https://github.com/BlinkDL/RWKV-LM/blob/main/RWKV-v4/src/model.py#L252C4-L255

testが重かったので少し修正しました。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
