### PR TITLE
FIX to register last values

### DIFF
--- a/src/models/components/ema_mixing.py
+++ b/src/models/components/ema_mixing.py
@@ -9,6 +9,7 @@ class EMAMixing(nn.Module):
         self.dim = dim
         self.factor = nn.Parameter(torch.rand(dim))
         self.sigmoid = nn.Sigmoid()
+        self.register_buffer("x_mix_last", None)
         self.x_mix_last = None
 
     # (len, batch, dim) -> (len, batch, dim)

--- a/src/models/components/previous_mixing.py
+++ b/src/models/components/previous_mixing.py
@@ -8,6 +8,7 @@ class PreviousMixing(nn.Module):
         super().__init__()
         self.dim = dim
         self.mix_factor = nn.Parameter(torch.rand(dim))
+        self.register_buffer("x_last", None)
         self.x_last = None
 
     # (len, *, dim) -> (len, *, dim)

--- a/src/models/components/time_mixing.py
+++ b/src/models/components/time_mixing.py
@@ -11,6 +11,8 @@ class TimeMixing(nn.Module):
         self.p_mix_k = PreviousMixing(dim)
         self.p_mix_v = PreviousMixing(dim)
         self.p_mix_r = PreviousMixing(dim)
+        self.register_buffer("numerator_last", None)
+        self.register_buffer("denominator_last", None)
         self.numerator_last = None
         self.denominator_last = None
         self.W_out = nn.Linear(dim, dim, bias=False)

--- a/tests/models/components/test_ema_mixing.py
+++ b/tests/models/components/test_ema_mixing.py
@@ -22,6 +22,7 @@ def test_ema_mixing(len, batch, dim):
     assert ema_mixing.x_mix_last is None
     x = ema_mixing(x)
     assert ema_mixing.x_mix_last is not None
+    assert "x_mix_last" in ema_mixing.state_dict()
     x = ema_mixing(x)
     ema_mixing.clear_hidden()
     assert ema_mixing.x_mix_last is None

--- a/tests/models/components/test_previous_mixing.py
+++ b/tests/models/components/test_previous_mixing.py
@@ -23,6 +23,7 @@ def test_previous_mixing(len, dim):
     assert previous_mixing.x_last is None
     x = previous_mixing(x)
     assert previous_mixing.x_last is not None
+    assert "x_last" in previous_mixing.state_dict()
     x = previous_mixing(x)
     previous_mixing.clear_hidden()
     assert previous_mixing.x_last is None

--- a/tests/models/components/test_time_mixing.py
+++ b/tests/models/components/test_time_mixing.py
@@ -24,6 +24,9 @@ def test_time_mixing(len, batch, dim):
     x = time_mixing(x)
     assert time_mixing.numerator_last is not None
     assert time_mixing.denominator_last is not None
+    assert "numerator_last" in time_mixing.state_dict()
+    assert "denominator_last" in time_mixing.state_dict()
+
     x = time_mixing(x)
     time_mixing.clear_hidden()
     assert time_mixing.numerator_last is None


### PR DESCRIPTION
## 概要

`Module.state_dict()`で`x_last`, `numerator_last`, `denominator_last`等を保存するよう修正しました。
学習を再スタートする際に重要になります。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を `pytest`または `make test`コマンドでローカルにテストしましたか?
- [x] `pre-commit run -a` または`make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
